### PR TITLE
Temoa work

### DIFF
--- a/Core_Model.py
+++ b/Core_Model.py
@@ -39,7 +39,7 @@ import time
 import datetime
 import numpy as np
 
-from Storage_Analysis import storage_analysis
+from Storage_Analysis import storage_analysis, no_storage_analysis
 
 from Save_Basic_Results import save_vector_results_as_csv
 from Save_Basic_Results import pickle_raw_results
@@ -73,8 +73,11 @@ def core_model_loop (global_dic, case_dic_list):
             # NOTE: THIS NEEDS TO BE FIXED UP FOR STORAGE2
             if 'STORAGE' in case_dic_list[case_index]['SYSTEM_COMPONENTS']:
                 sdic = storage_analysis(global_dic,case_dic_list[case_index],result_dic)
+            else:
+                sdic = no_storage_analysis()
                 for key in sdic.keys():
                     result_dic[key] = sdic[key]
+
 
         else:
 

--- a/Core_Model.py
+++ b/Core_Model.py
@@ -654,6 +654,7 @@ def core_model (global_dic, case_dic):
         result['CURTAILMENT_WIND'] = -1 * np.ones(demand_series.size)
         result['CURTAILMENT_SOLAR2'] = -1 * np.ones(demand_series.size)
         result['CURTAILMENT_WIND2'] = -1 * np.ones(demand_series.size)
+        result['CURTAILMENT_CSP'] = -1 * np.ones(demand_series.size)
         result['CURTAILMENT_NUCLEAR'] = -1 * np.ones(demand_series.size)
  
         result['DISPATCH_TO_STORAGE'] = -1 * np.ones(demand_series.size)
@@ -848,6 +849,7 @@ def core_model (global_dic, case_dic):
             result['DISPATCH_TO_CSP_STORAGE'] = dispatch_to_csp_storage/numerics_demand_scaling
             result['DISPATCH_FROM_CSP'] = dispatch_from_csp/numerics_demand_scaling
             result['ENERGY_CSP_STORAGE'] = energy_csp_storage/numerics_demand_scaling
+            result['CURTAILMENT_CSP'] = (capacity_csp-dispatch_from_csp)/numerics_demand_scaling
 
         if 'UNMET_DEMAND' in system_components:
             result['DISPATCH_UNMET_DEMAND'] = np.array(dispatch_unmet_demand.value).flatten()/numerics_demand_scaling

--- a/Quick_Look.py
+++ b/Quick_Look.py
@@ -882,15 +882,20 @@ def plot_results_storage_1scenario (input_data, hours_to_avg = None, start_hour 
 
     pdf_each = input_data['pdf_each']
     
-    price = copy.deepcopy(input_data['PRICE'])
-    max_headroom = copy.deepcopy(input_data['max_headroom'])
-    revenue_elec_storage = copy.deepcopy(input_data['net_revenue'])
-    net_revenue = copy.deepcopy(input_data['net_revenue'])
-    net_cost_elec_storage = copy.deepcopy(input_data['net_cost_elec_storage'])
-    # note: net_revenue = revenue_elec_storage - net_cost_elec_storage
-    dispatch_to_storage = copy.deepcopy(input_data['DISPATCH_TO_STORAGE'])
-    dispatch_from_storage = copy.deepcopy(input_data['DISPATCH_FROM_STORAGE'])
-    energy_storage = copy.deepcopy(input_data['ENERGY_STORAGE'])
+    # Catch cases where storage was not included in system
+    try:
+        price = copy.deepcopy(input_data['PRICE'])
+        max_headroom = copy.deepcopy(input_data['max_headroom'])
+        revenue_elec_storage = copy.deepcopy(input_data['net_revenue'])
+        net_revenue = copy.deepcopy(input_data['net_revenue'])
+        net_cost_elec_storage = copy.deepcopy(input_data['net_cost_elec_storage'])
+        # note: net_revenue = revenue_elec_storage - net_cost_elec_storage
+        dispatch_to_storage = copy.deepcopy(input_data['DISPATCH_TO_STORAGE'])
+        dispatch_from_storage = copy.deepcopy(input_data['DISPATCH_FROM_STORAGE'])
+        energy_storage = copy.deepcopy(input_data['ENERGY_STORAGE'])
+    except KeyError:
+        print("Storage not included in system, skipping plotting storage results from Quick_Look.plot_results_storage_1scenario")
+        return
 
     case_name = input_data['CASE_NAME']
     

--- a/Save_Basic_Results.py
+++ b/Save_Basic_Results.py
@@ -203,6 +203,9 @@ def save_vector_results_as_csv( global_dic, case_dic, result_dic ):
     header_list += ['cutailment wind2 (kW)']
     series_list.append( result_dic['CURTAILMENT_WIND2'].flatten() )
     
+    header_list += ['cutailment csp (kW)']
+    series_list.append( result_dic['CURTAILMENT_CSP'].flatten() )
+    
     header_list += ['cutailment nuclear (kW)']
     series_list.append( result_dic['CURTAILMENT_NUCLEAR'].flatten() )
     
@@ -595,6 +598,9 @@ def save_basic_results( global_dic, case_dic_list ):
     
         header_list += ['dispatch from csp (kW)']
         series_list.append( case_list_dic['DISPATCH_FROM_CSP'])
+    
+        header_list += ['curtailment csp (kW)']
+        series_list.append( case_list_dic['CURTAILMENT_CSP'])
 
     #Results: UNMET_DEMAND   
     if 'UNMET_DEMAND' in components: 

--- a/Save_Basic_Results.py
+++ b/Save_Basic_Results.py
@@ -318,7 +318,7 @@ def save_basic_results( global_dic, case_dic_list ):
         series_list.append( case_list_dic['SOLAR_SERIES'])
     
     # Input: SOLAR2
-    if 'SOLAR' in components: 
+    if 'SOLAR2' in components: 
         header_list += ['fixed cost solar2 ($/kW/h)']
         series_list.append( case_list_dic['FIXED_COST_SOLAR2'])
     

--- a/Storage_Analysis.py
+++ b/Storage_Analysis.py
@@ -174,3 +174,22 @@ def storage_analysis(global_dic,case_dic,result_dic):
             #  <revenue_elec_storage> revenue from electricity sold from storage in each hour
         
     return storage_dic
+
+
+# Need to return an empty storage dict so that the restults keys are consistent
+# across all cases
+def no_storage_analysis():
+
+    storage_dic = {
+            "max_headroom":             -1,
+            "mean_storage_time":        -1,
+            "max_storage_time":         -1,
+            "elec_cost_elec_storage":   -1,
+            "var_cost_elec_storage":    -1,
+            "net_cost_elec_storage":    -1,
+            "revenue_elec_storage":     -1,
+            "net_revenue":              -1,
+            "net_revenue_perkWh":       -1,
+            "storage_cost_perkWh":      -1
+            }
+    return storage_dic


### PR DESCRIPTION
* Add CURTAILMENT_CSP to results
* Deals with cases where batteries and storage are included in one case but not others.  This is dealt with by skipping the plotting of storage results when storage is not included.

@KenCaldeira, is there a much more graceful way to do both of these?